### PR TITLE
Develop v0.1.2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,12 @@
 # History
 
+## 0.1.2 (2022-03-29)
+- Allows `array_like.__array__()` to throw exceptions.
+  - Now, `array_like_info(obj)` degrades to vanilla `repr(obj)` if `obj.__array__()` throws exception. Before, it did nothing, but let caller to handle the exception.
+- rename `arraydebug.recover_repr()` to `arraydebug.disable()`.
+- rename `arraydebug.inject_repr()` to `arraydebug.enable()`.
+  - `enable()` also refresh `arraydebug.repr_fn_table` now.
+
 ## 0.1.0 (2022-03-27)
 
 * First release on PyPI.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ArrayDebug
 
 [![image](https://img.shields.io/pypi/v/arraydebug.svg)](https://pypi.python.org/pypi/arraydebug)
-![buld](https://github.com/liqimai/arraydebug/actions/workflows/build.yaml/badge.svg)
+![build](https://github.com/liqimai/arraydebug/actions/workflows/build.yaml/badge.svg)
 [![Updates](https://pyup.io/repos/github/liqimai/arraydebug/shield.svg)](https://pyup.io/repos/github/liqimai/arraydebug/)
 [![support-version](https://img.shields.io/pypi/pyversions/arraydebug)](https://img.shields.io/pypi/pyversions/arraydebug)
 <!-- [![Documentation Status](https://readthedocs.org/projects/arraydebug/badge/?version=latest)](https://arraydebug.readthedocs.io/en/latest/?version=latest) -->
@@ -13,16 +13,23 @@ objects.
 -   Support python 3.6+
 <!-- -   Documentation: <https://arraydebug.readthedocs.io>. -->
 
-## Usage
 
-All you need is to `import arraydebug` after `numpy`, `torch`, `pandas`, etc.
+## Installation
+
+```shell
+$ pip install arraydebug
+```
+
+## Get Started
+
+All you need is to `import arraydebug` __after__ numpy, torch, pandas, etc.
 
 ```python
->>> import numpy as np
->>> import torch
->>> import pandas as pd
->>> ...
->>> import arraydebug # import at last
+import numpy as np
+import torch
+import pandas as pd
+...
+import arraydebug # import at last
 ```
 
 Then you will get information of the array-like object shown in the debugger, like:
@@ -42,7 +49,7 @@ It works with all debuggers which rely on `repr` function to display variable in
 
 
 ### IPython
-```ipython
+```python
 In [1]: import torch
 
 In [2]: import arraydebug
@@ -90,7 +97,72 @@ tensor([[<span class="pl-c1">1.</span>, 1., 1., 1.],
         [1., 1., 1., 1.]], requires_grad=True)</code>
 </pre> -->
 
+## Usage
 
+Import `arraydebug` __after__ numpy, torch, pandas, etc.
+
+```python
+import torch
+import arraydebug # import at last
+```
+Then you will get information of the array-like object shown in the debugger, like:
+```
+<Tensor: shape=(6, 4), dtype=float32, device='cpu', requires_grad=True>
+```
+
+ArrayDebug searches imported packages for array_like objects, and provides debug information for them. So, it important to import `arraydebug` after them.
+
+
+### How does it work?
+Behind the hood, this is achieved by modifying behavior of `repr()`. So, all debuggers that relies on `repr()` will display the debug information.
+
+```python
+>>> import torch
+>>> import arraydebug
+>>> tensor = torch.ones(3, requires_grad=True)
+>>> print(repr(tensor))
+<Tensor: shape=(3,), dtype=float32, device='cpu', requires_grad=True>
+tensor([1., 1., 1.], requires_grad=True)
+```
+
+### Enable and disable
+To recover the vanilla `repr()`, you may disable ArrayDebug by `disable()`,
+```python
+>>> arraydebug.disable()
+>>> print(repr(tensor))
+tensor([1., 1., 1.], requires_grad=True)
+```
+
+or enable ArrayDebug again by `enable()`.
+```python
+>>> arraydebug.enable()
+>>> print(repr(tensor))
+<Tensor: shape=(3,), dtype=float32, device='cpu', requires_grad=True>
+tensor([1., 1., 1.], requires_grad=True)
+```
+
+This is also useful when you import some modules after ArrayDebug, and want to enable ArrayDebug for them:
+```python
+>>> import arraydebug
+>>> import torch
+>>> print(repr(torch.ones(3, requires_grad=True)))
+<Tensor: shape=(3,), dtype=float32, device='cpu', requires_grad=True>
+tensor([1., 1., 1.], requires_grad=True)
+```
+
+### Customize
+
+You can register your own debug info by `register_repr()`.
+```python
+>>> class A:
+...     def __init__(self, x):
+...         self.x = x
+...
+>>> info_fn = lambda a: f'<class A object with x={a.x}>'
+>>> arraydebug.register_repr(A, info_fn)
+>>> print(repr(A(5)))
+<class A object with x=5>
+```
 
 ## Credits
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.1.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
     project_urls={
         "Bug Tracker": "https://github.com/liqimai/arraydebug/issues",
     },
-    version="0.1.1",
+    version="0.1.2",
     zip_safe=True,
 )

--- a/src/arraydebug/__init__.py
+++ b/src/arraydebug/__init__.py
@@ -1,7 +1,6 @@
 from arraydebug.core import (  # noqa
-    recover_repr,
-    inject_repr,
-    register_reprs,
+    disable,
+    enable,
     register_repr,
     repr_fn_table,
 )
@@ -11,5 +10,4 @@ __email__ = "liqimai@qq.com"
 __version__ = "0.1.1"
 
 
-register_reprs()
-inject_repr()
+enable()

--- a/src/arraydebug/__init__.py
+++ b/src/arraydebug/__init__.py
@@ -7,7 +7,7 @@ from arraydebug.core import (  # noqa
 
 __author__ = """Qimai Li"""
 __email__ = "liqimai@qq.com"
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 
 enable()

--- a/src/arraydebug/array_like.py
+++ b/src/arraydebug/array_like.py
@@ -21,7 +21,9 @@ def array_like_info(array_like) -> str:
     2013-01-05  1016  1017  1018  1019
     2013-01-06  1020  1021  1022  1023
     """
-    array = array_like.__array__()
-    return f"""\
-<{array_like.__class__.__name__}: shape={array.shape}, dtype={array.dtype}>
-{array_like.__repr__()}"""
+    try:
+        array = array_like.__array__()
+        info = f"<{array_like.__class__.__name__}: shape={array.shape}, dtype={array.dtype}>\n"
+    except:
+        info = ""
+    return f"""{info}{array_like.__repr__()}"""

--- a/src/arraydebug/core.py
+++ b/src/arraydebug/core.py
@@ -38,11 +38,11 @@ def _new_repr(obj) -> str:
         return _default_repr(obj)
 
 
-def recover_repr() -> None:
+def disable() -> None:
     _builtins.repr = _default_repr
 
 
-def inject_repr() -> None:
+def enable() -> None:
     register_reprs()
     _builtins.repr = _new_repr
 

--- a/src/arraydebug/core.py
+++ b/src/arraydebug/core.py
@@ -43,6 +43,7 @@ def recover_repr() -> None:
 
 
 def inject_repr() -> None:
+    register_reprs()
     _builtins.repr = _new_repr
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,4 +3,4 @@ import torch  # noqa
 import pandas  # noqa
 import arraydebug  # noqa
 
-arraydebug.register_reprs()
+arraydebug.enable()

--- a/tests/test_arraydebug.py
+++ b/tests/test_arraydebug.py
@@ -27,3 +27,12 @@ class TestArraydebug(unittest.TestCase):
 
         arraydebug.disable()
         self.assertEqual(repr(arr), "array([0, 1, 2, 3])")
+
+    def test_register_repr(self):
+        class A:
+            def __init__(self, x):
+                self.x = x
+
+        info_fn = lambda a: f"<class A object with x={a.x}>"
+        arraydebug.register_repr(A, info_fn)
+        self.assertEqual(repr(A(5)), "<class A object with x=5>")

--- a/tests/test_arraydebug.py
+++ b/tests/test_arraydebug.py
@@ -9,22 +9,21 @@ import arraydebug
 
 class TestArraydebug(unittest.TestCase):
     def setUp(self) -> None:
-        arraydebug.register_reprs()
-        arraydebug.inject_repr()
+        arraydebug.enable()
 
     def tearDown(self) -> None:
-        arraydebug.inject_repr()
+        arraydebug.enable()
 
     def test(self):
         self.assertEqual(repr(1), "1")
         self.assertEqual(repr("abc"), "'abc'")
         self.assertEqual(repr([1, 2, 3, 4]), "[1, 2, 3, 4]")
 
-    def test_recover_repr(self):
+    def test_enable(self):
         arr = np.arange(4)
 
-        arraydebug.inject_repr()
+        arraydebug.enable()
         self.assertEqual(repr(arr), "<ndarray: shape=(4,), dtype=int64>\narray([0, 1, 2, 3])")
 
-        arraydebug.recover_repr()
+        arraydebug.disable()
         self.assertEqual(repr(arr), "array([0, 1, 2, 3])")

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -7,8 +7,7 @@ import arraydebug  # noqa
 
 class TestNumpy(unittest.TestCase):
     def setUp(self) -> None:
-        arraydebug.register_reprs()
-        arraydebug.inject_repr()
+        arraydebug.enable()
 
     def test_1D(self):
         """

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -7,8 +7,7 @@ import arraydebug  # noqa
 
 class TestTorch(unittest.TestCase):
     def setUp(self) -> None:
-        arraydebug.register_reprs()
-        arraydebug.inject_repr()
+        arraydebug.enable()
 
     def test_1D(self):
         """

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -61,3 +61,41 @@ class TestTorch(unittest.TestCase):
         arr = torch.arange(3 * 4, dtype=torch.float64).reshape(3, 4)
         arr.requires_grad_(True)
         self.assertEqual(repr(arr), cleandoc(self.test_requires_grad.__doc__))
+
+
+class TestTorchWithoutArrayDebug(unittest.TestCase):
+    def setUp(self) -> None:
+        # disable customized repr function for torch.Tensor
+        del arraydebug.repr_fn_table[torch.Tensor]
+
+    def tearDown(self) -> None:
+        from arraydebug.torch import tensor_info
+
+        arraydebug.register_repr(torch.Tensor, tensor_info)
+
+    def test_no_grad(self):
+        # without customized repr, `torch.Tensor` degrades to a normal
+        # array_like object.
+        """
+        <Tensor: shape=(3, 4), dtype=int64>
+        tensor([[ 0,  1,  2,  3],
+                [ 4,  5,  6,  7],
+                [ 8,  9, 10, 11]])
+        """
+        arr = torch.arange(3 * 4).reshape(3, 4)
+        self.assertEqual(repr(arr), cleandoc(self.test_no_grad.__doc__))
+
+    def test_grad(self):
+        # Without customized repr, `torch.Tensor` degrades to a normal
+        # array_like object, which relies on `tensor.__array__()` to get
+        # the info. However, `tensor.__array__()` throws exception when
+        # `tensor.requires_grad == True`, and thus `repr(tensor)`
+        # behaves same as vanilla `repr` function.
+        """
+        tensor([[ 0.,  1.,  2.,  3.],
+                [ 4.,  5.,  6.,  7.],
+                [ 8.,  9., 10., 11.]], dtype=torch.float64, requires_grad=True)
+        """
+        arr = torch.arange(3 * 4, dtype=torch.float64).reshape(3, 4)
+        arr.requires_grad_(True)
+        self.assertEqual(repr(arr), cleandoc(self.test_grad.__doc__))


### PR DESCRIPTION
- Allows `array_like.__array__()` to throw exceptions.
  - Now, `array_like_info(obj)` degrades to vanilla `repr(obj)` if `obj.__array__()` throws exception. Before, it did nothing, but let caller to handle the exception.
- rename `arraydebug.recover_repr()` to `arraydebug.disable()`.
- rename `arraydebug.inject_repr()` to `arraydebug.enable()`.
  - `enable()` also refresh `arraydebug.repr_fn_table` now.
